### PR TITLE
Implement handling of event interests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ pkg-config = "0.3"
 gstreamer = "0.17"
 glib = "0.14"
 tracing = "0.1"
+tracing-subscriber = "0.2"
 
 [package.metadata.docs.rs]
 features = ["tracing-gstreamer-docs"]

--- a/src/callsite.rs
+++ b/src/callsite.rs
@@ -1,29 +1,62 @@
-use std::sync::atomic::{AtomicPtr, Ordering};
+use std::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
 use tracing_core::{Callsite, Interest, Metadata};
 
-pub(super) struct GstCallsite(AtomicPtr<Metadata<'static>>);
+pub(super) struct GstCallsite {
+    interest: AtomicUsize,
+    metadata: AtomicPtr<Metadata<'static>>,
+}
 
 impl GstCallsite {
     pub(super) fn make_static() -> &'static Self {
         #[allow(unused_unsafe)]
         unsafe {
             // SAFETY: for `metadata` to be sound this must initialize with a null pointer.
-            Box::leak(Box::new(GstCallsite(AtomicPtr::new(std::ptr::null_mut()))))
+            Box::leak(Box::new(GstCallsite {
+                interest: AtomicUsize::new(0),
+                metadata: AtomicPtr::new(std::ptr::null_mut()),
+            }))
         }
     }
-    pub(super) fn set_metadata(&self, meta: &'static Metadata<'static>) {
-        self.0.store(meta as *const _ as _, Ordering::Release);
+    pub(super) fn set_metadata(&'static self, meta: &'static Metadata<'static>) {
+        self.metadata
+            .compare_exchange(
+                std::ptr::null_mut(),
+                meta as *const _ as _,
+                Ordering::Release,
+                Ordering::Relaxed,
+            )
+            .expect("set_metadata should only be called once");
+        tracing_core::callsite::register(self);
+    }
+
+    pub(super) fn interest(&self) -> Interest {
+        match self.interest.load(Ordering::Acquire) {
+            1 => Interest::never(),
+            2 => Interest::sometimes(),
+            3 => Interest::always(),
+            _ => panic!("attempting to obtain callsite's interest before its been set"),
+        }
     }
 }
 
 impl Callsite for GstCallsite {
-    fn set_interest(&self, _: Interest) {}
+    fn set_interest(&self, interest: Interest) {
+        self.interest.store(
+            match () {
+                _ if interest.is_never() => 1,
+                _ if interest.is_always() => 3,
+                _ => 2,
+            },
+            Ordering::Release,
+        );
+    }
+
     fn metadata(&self) -> &Metadata<'_> {
         unsafe {
             // SAFETY: this type always contains nullptr (and `as_ref` will return `None`) until it
             // is initialized in the `set_metadata` function. `set_metadata` will always set a
             // valid pointer by definition of storing the address of a `&'static` reference.
-            self.0
+            self.metadata
                 .load(Ordering::Acquire)
                 .as_ref()
                 .expect("metadata must have been initialized already!")


### PR DESCRIPTION
This was pretty fun a headscratcher. What happens here is that any time
a new Callsite is created (conceptually a location in code which
contains a log statement) we must register ourselves with tracing
runtime and obtain subscribers' interest in the event, and filter
accordingly.

This avoids unnecessarily spending timme on invoking all of the
subscriber machineries among other things. As a future optimisation on
our side, we can also check the interest before allocating/leaking the
`Metadata` and `Callsite`, at the cost of checking the interest twice
when we do actually register the callsite.