### PR TITLE
Address breaking changes in tracing_core

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-gstreamer"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2018"
 authors = ["Simonas Kazlauskas <tracing-gstreamer@kazlauskas.me>"]
 license = "MIT OR Apache-2.0"
@@ -20,13 +20,13 @@ crate-type = ["cdylib", "rlib"]
 libc = "0.2.69"
 once_cell = "1.8.0"
 tracing = "0.1.0"
-tracing-core = ">=0.1.17, <=0.1.21"
+tracing-core = "0.1.17"
 gstreamer = "0.18.0"
 thread_local = "1.0.0"
 
 [dev-dependencies]
 tracing = "0.1.0"
-tracing-subscriber = "0.2.0"
+tracing-subscriber = "0.2.4"
 tracing-tracy = "0.7.0"
 
 [package.metadata.docs.rs]

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,3 +1,4 @@
+use crate::{callsite::GstCallsiteKind, state_desc, PadFlags};
 use gstreamer::{
     ffi::{
         gst_debug_add_log_function, gst_debug_category_get_name, gst_debug_message_get,
@@ -12,9 +13,7 @@ use gstreamer::{
 };
 use libc::{c_char, c_int, c_void};
 use std::{convert::TryFrom, ffi::CStr};
-use tracing_core::{Callsite, Event, Kind, Level};
-
-use crate::{state_desc, PadFlags};
+use tracing_core::{Callsite, Event, Level};
 
 unsafe extern "C" fn log_callback(
     category: *mut gstreamer::ffi::GstDebugCategory,
@@ -71,7 +70,7 @@ unsafe extern "C" fn log_callback(
             Some(&file),
             Some(&module),
             Some(line as u32),
-            Kind::EVENT,
+            GstCallsiteKind::Event,
             &[
                 "message",
                 "gobject.address",

--- a/src/tracer.rs
+++ b/src/tracer.rs
@@ -1,5 +1,4 @@
-use std::cell::RefCell;
-
+use crate::callsite::GstCallsiteKind;
 use glib::subclass::basic;
 use gstreamer::{
     glib,
@@ -8,8 +7,8 @@ use gstreamer::{
     traits::{GstObjectExt, PadExt},
     Buffer, FlowReturn, Object, Pad, Query, Tracer,
 };
+use std::cell::RefCell;
 use tracing::{span::Attributes, Callsite, Dispatch, Id};
-use tracing_core::Kind;
 
 struct EnteredSpan {
     id: Id,
@@ -51,7 +50,7 @@ impl TracingTracerPriv {
             None,
             None,
             None,
-            Kind::SPAN,
+            GstCallsiteKind::Span,
             &["gstpad.state", "gstpad.parent.name"],
         );
         let interest = callsite.interest();


### PR DESCRIPTION
tracing-core 0.1.22 introduced an unfortunate breaking change. One of
the public types was intended to be non-exhaustive, but turns out
`rustc` was smart enough to make it exhaustive anyway.

The hope was that there wouldn't be any way to obtain the `Kind` from a
`Metadata` and even less of a reason to actually match on one. Alas, it
turned out to be not true for us, where we were trying to open code an
implementation of `PartialEq for Kind`.

In retrospective we should've been using our own defined type anyway and
deriving `PartialEq` as that's just cleaner (we don't need to think
about any future variants added to `Kind`.)

Fixes #6