### PR TITLE
Specify correct bounds for dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-gstreamer"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2018"
 authors = ["Simonas Kazlauskas <tracing-gstreamer@kazlauskas.me>"]
 license = "MIT OR Apache-2.0"
@@ -17,17 +17,17 @@ harness = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-libc = "0.2"
-once_cell = "1.8"
-tracing = "0.1"
-tracing-core = "0.1"
-gstreamer = "0.18"
-thread_local = "1"
+libc = "0.2.69"
+once_cell = "1.8.0"
+tracing = "0.1.0"
+tracing-core = ">=0.1.17, <=0.1.21"
+gstreamer = "0.18.0"
+thread_local = "1.0.0"
 
 [dev-dependencies]
-tracing = "0.1"
-tracing-subscriber = "0.2"
-tracing-tracy = "0.7"
+tracing = "0.1.0"
+tracing-subscriber = "0.2.0"
+tracing-tracy = "0.7.0"
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "tracing_gstreamer_docs"]


### PR DESCRIPTION
This is a preparation for a patch version that allows 0.3.0 series
compile in a world where tracing-core 0.1.21 exists.