### PR TITLE
Add more information in traces from GstTracer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,6 @@ tracing-tracy = "0.10"
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "tracing_gstreamer_docs"]
+
+[features]
+v1_22 = ["gstreamer/v1_22"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,14 @@ fn query_name(query: &gstreamer::QueryRef) -> &'static str {
     }
 }
 
+fn message_name(message: &gstreamer::Message) -> &'static str {
+    use gstreamer::ffi as gffi;
+    unsafe {
+        let type_ = gffi::gst_message_type_get_name((*message.as_ptr()).type_);
+        std::ffi::CStr::from_ptr(type_).to_str().unwrap()
+    }
+}
+
 /// Enable the integration between GStreamer logging system and the `tracing` library.
 ///
 /// Once enabled the default [`tracing::Subscriber`][tracing_core::subscriber::Subscriber] will

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,14 @@ fn state_desc(state: gstreamer::ffi::GstState) -> &'static str {
     }
 }
 
+fn query_name(query: &gstreamer::QueryRef) -> &'static str {
+    use gstreamer::ffi as gffi;
+    unsafe {
+        let type_ = gffi::gst_query_type_get_name((*query.as_ptr()).type_);
+        std::ffi::CStr::from_ptr(type_).to_str().unwrap()
+    }
+}
+
 /// Enable the integration between GStreamer logging system and the `tracing` library.
 ///
 /// Once enabled the default [`tracing::Subscriber`][tracing_core::subscriber::Subscriber] will

--- a/src/tracer.rs
+++ b/src/tracer.rs
@@ -51,7 +51,7 @@ impl TracingTracerPriv {
             None,
             None,
             GstCallsiteKind::Span,
-            &["gstpad.state", "gstpad.parent.name"],
+            &["gstpad.state", "gstpad.name", "gstpad.parent.name"],
         );
         let interest = callsite.interest();
         if interest.is_never() {
@@ -65,6 +65,8 @@ impl TracingTracerPriv {
         let gstpad_flags_value = Some(tracing_core::field::display(crate::PadFlags(
             pad.pad_flags().bits(),
         )));
+        let name = pad.name();
+        let name_value = Some(name.as_str());
         let gstpad_parent = pad.parent_element();
         let gstpad_parent_name_value = gstpad_parent.map(|p| p.name());
         let gstpad_parent_name_value = gstpad_parent_name_value.as_ref().map(|n| n.as_str());
@@ -73,6 +75,7 @@ impl TracingTracerPriv {
         let values = field_values![fields_iter =>
             // /!\ /!\ /!\ Must be in the same order as the field list above /!\ /!\ /!\
             "gstpad.flags" = gstpad_flags_value;
+            "gstpad.name" = name_value;
             "gstpad.parent.name" = gstpad_parent_name_value;
         ];
         let valueset = fields.value_set(&values);

--- a/src/tracer.rs
+++ b/src/tracer.rs
@@ -23,17 +23,32 @@ pub struct TracingTracerPriv {
 struct SpanBuilder<'a> {
     name: &'static str,
     pad: Option<&'a Pad>,
+    element: Option<&'a gstreamer::Element>,
     event: Option<&'a gstreamer::Event>,
     query: Option<&'a gstreamer::QueryRef>,
+    message: Option<&'a gstreamer::Message>,
 }
 
 impl<'a> SpanBuilder<'a> {
+    fn new_element(name: &'static str, element: &'a gstreamer::Element) -> Self {
+        Self {
+            name,
+            pad: None,
+            event: None,
+            query: None,
+            element: Some(element),
+            message: None,
+        }
+    }
+
     fn new_pad(name: &'static str, pad: &'a Pad) -> Self {
         Self {
             name,
             pad: Some(pad),
             event: None,
             query: None,
+            element: None,
+            message: None,
         }
     }
 
@@ -51,6 +66,13 @@ impl<'a> SpanBuilder<'a> {
         }
     }
 
+    fn message(self, message: &'a gstreamer::Message) -> Self {
+        Self {
+            message: Some(message),
+            ..self
+        }
+    }
+
     fn build(self, tracer: &TracingTracerPriv) {
         let callsite = crate::callsite::DynamicCallsites::get().callsite_for(
             tracing::Level::ERROR,
@@ -61,7 +83,13 @@ impl<'a> SpanBuilder<'a> {
             None,
             GstCallsiteKind::Span,
             self.pad.as_ref().map_or(
-                unreachable!(),
+                // List of fields for element traces
+                &[
+                    "gstelement.name",
+                    "gstelement.state",
+                    "gstelement.next_state",
+                    "gstelement.message.type",
+                ],
                 |_| {
                     // List of fields for pad traces
                     &[
@@ -83,33 +111,59 @@ impl<'a> SpanBuilder<'a> {
         if !dispatch.enabled(meta) {
             return;
         }
-        let pad = self.pad.unwrap();
-        let gstpad_flags_value = Some(tracing_core::field::display(crate::PadFlags(
-            pad.pad_flags().bits(),
-        )));
-        let name = pad.name();
-        let name_value = Some(name.as_str());
-        let gstpad_parent = pad.parent_element();
-        let gstpad_parent_name_value = gstpad_parent.map(|p| p.name());
-        let gstpad_parent_name_value = gstpad_parent_name_value.as_ref().map(|n| n.as_str());
         let fields = meta.fields();
+
         let mut fields_iter = fields.into_iter();
-        let event_type = self.event.map(|e| e.type_().name());
-        let event_type_name = event_type.as_ref().map(|n| n.as_str());
-        let query_type_name = self.query.map(|q| crate::query_name(q));
+        if let Some(element) = self.element {
+            let (_, state, next_state) =
+                element.state(Some(gstreamer::ClockTime::from_mseconds(0)));
+            let state_value = Some(crate::state_desc(state as i32));
+            let next_state_value = Some(crate::state_desc(next_state as i32));
+            let name = element.name();
+            let name_value = Some(name.as_str());
+            let message_type_name = self.message.map(crate::message_name);
 
-        let values = field_values![fields_iter =>
-            // /!\ /!\ /!\ Must be in the same order as the list of fields for pad above /!\ /!\ /!\
-            "gstpad.flags" = gstpad_flags_value;
-            "gstpad.name" = name_value;
-            "gstpad.parent.name" = gstpad_parent_name_value;
-            "gstpad.event.type" = event_type_name;
-            "gstpad.query.type" = query_type_name;
-        ];
+            // /!\ /!\ /!\ Must be in the same order as the list of fields for element above /!\ /!\ /!\
+            let values = field_values![fields_iter =>
+                "gstelement.name" = name_value;
+                "gstelement.state" = state_value;
+                "gstelement.next_state" = next_state_value;
+                "gstelement.message.type" = message_type_name;
+            ];
 
-        let valueset = fields.value_set(&values);
-        let attrs = tracing::span::Attributes::new_root(meta, &valueset);
-        tracer.push_span(dispatch, attrs);
+            let valueset = fields.value_set(&values);
+            let attrs = tracing::span::Attributes::new_root(meta, &valueset);
+
+            tracer.push_span(dispatch, attrs);
+        } else {
+            let pad = self.pad.unwrap();
+
+            let gstpad_flags_value = Some(tracing_core::field::display(crate::PadFlags(
+                pad.pad_flags().bits(),
+            )));
+            let name = pad.name();
+            let name_value = Some(name.as_str());
+            let gstpad_parent = pad.parent_element();
+            let gstpad_parent_name_value = gstpad_parent.map(|p| p.name());
+            let gstpad_parent_name_value = gstpad_parent_name_value.as_ref().map(|n| n.as_str());
+            let event_type = self.event.map(|e| e.type_().name());
+            let event_type_name = event_type.as_ref().map(|n| n.as_str());
+            let query_type_name = self.query.map(crate::query_name);
+
+            let values = field_values![fields_iter =>
+                // /!\ /!\ /!\ Must be in the same order as the list of fields for pad above /!\ /!\ /!\
+                "gstpad.flags" = gstpad_flags_value;
+                "gstpad.name" = name_value;
+                "gstpad.parent.name" = gstpad_parent_name_value;
+                "gstpad.event.type" = event_type_name;
+                "gstpad.query.type" = query_type_name;
+            ];
+
+            let valueset = fields.value_set(&values);
+            let attrs = tracing::span::Attributes::new_root(meta, &valueset);
+
+            tracer.push_span(dispatch, attrs);
+        }
     }
 }
 
@@ -177,6 +231,11 @@ impl ObjectImpl for TracingTracerPriv {
         self.register_hook(TracerHook::PadPushEventPre);
         self.register_hook(TracerHook::PadPullRangePost);
         self.register_hook(TracerHook::PadPullRangePre);
+        self.register_hook(TracerHook::ElementChangeStatePre);
+        self.register_hook(TracerHook::ElementChangeStatePost);
+
+        self.register_hook(TracerHook::ElementPostMessagePre);
+        self.register_hook(TracerHook::ElementPostMessagePost);
 
         #[cfg(feature = "v1_22")]
         {
@@ -189,6 +248,26 @@ impl ObjectImpl for TracingTracerPriv {
 impl GstObjectImpl for TracingTracerPriv {}
 
 impl TracerImpl for TracingTracerPriv {
+    fn element_post_message_pre(
+        &self,
+        _ts: u64,
+        element: &gstreamer::Element,
+        message: &gstreamer::Message,
+    ) {
+        SpanBuilder::new_element("message", element)
+            .message(message)
+            .build(self);
+    }
+
+    fn element_change_state_pre(
+        &self,
+        _ts: u64,
+        element: &gstreamer::Element,
+        _change: gstreamer::StateChange,
+    ) {
+        SpanBuilder::new_element("element_state", element).build(self);
+    }
+
     #[cfg(feature = "v1_22")]
     fn pad_chain_pre(&self, _: u64, pad: &Pad, _: &Buffer) {
         self.pad_pre("pad_chain", pad);
@@ -240,6 +319,20 @@ impl TracerImpl for TracingTracerPriv {
     }
 
     fn pad_query_post(&self, _: u64, _: &Pad, _: &gstreamer::QueryRef, _: bool) {
+        self.pop_span();
+    }
+
+    fn element_change_state_post(
+        &self,
+        _: u64,
+        _: &gstreamer::Element,
+        _: gstreamer::StateChange,
+        _: Result<gstreamer::StateChangeSuccess, gstreamer::StateChangeError>,
+    ) {
+        self.pop_span();
+    }
+
+    fn element_post_message_post(&self, _ts: u64, _element: &gstreamer::Element, _success: bool) {
         self.pop_span();
     }
 }

--- a/src/tracer.rs
+++ b/src/tracer.rs
@@ -118,12 +118,23 @@ impl ObjectImpl for TracingTracerPriv {
         self.register_hook(TracerHook::PadPushEventPre);
         self.register_hook(TracerHook::PadPullRangePost);
         self.register_hook(TracerHook::PadPullRangePre);
+
+        #[cfg(feature = "v1_22")]
+        {
+            self.register_hook(TracerHook::PadChainPre);
+            self.register_hook(TracerHook::PadChainPost);
+        }
     }
 }
 
 impl GstObjectImpl for TracingTracerPriv {}
 
 impl TracerImpl for TracingTracerPriv {
+    #[cfg(feature = "v1_22")]
+    fn pad_chain_pre(&self, _: u64, pad: &Pad, _: &Buffer) {
+        self.pad_pre("pad_chain", pad);
+    }
+
     fn pad_push_pre(&self, _: u64, pad: &Pad, _: &Buffer) {
         self.pad_pre("pad_push", pad);
     }
@@ -157,6 +168,11 @@ impl TracerImpl for TracingTracerPriv {
     }
 
     fn pad_push_post(&self, _: u64, _: &Pad, _: Result<FlowSuccess, FlowError>) {
+        self.pop_span();
+    }
+
+    #[cfg(feature = "v1_22")]
+    fn pad_chain_post(&self, _: u64, _: &Pad, _: Result<FlowSuccess, FlowError>) {
         self.pop_span();
     }
 


### PR DESCRIPTION
- **Add pad name in traces**  
- **Add pad chain infos**  
- **tracer: Factor out a SpanBuilder struct to log different objects**    
  It is useful in the logs to know the query/message/event that are being
  handled so we log them.

- **tracer: Log elements state change and messages on the bus**  %        