### PR TITLE
Allow using the tracer in any GStreamer application

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,11 +23,15 @@ tracing = "0.1.0"
 tracing-core = "0.1.17"
 gstreamer = "0.20"
 thread_local = "1.0.0"
+tracing-chrome = "0.7.0"
+tracing-subscriber = "0.3"
 
 [dev-dependencies]
 tracing = "0.1.0"
-tracing-subscriber = "0.3"
 tracing-tracy = "0.10"
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "tracing_gstreamer_docs"]
+
+[features]
+tracing-chrome = []

--- a/README.mkd
+++ b/README.mkd
@@ -110,3 +110,73 @@ Similar results can be achieved with some other subscribers as well.
 
 [gsttracing]: https://gstreamer.freedesktop.org/documentation/additional/design/tracing.html
 [`tracing`]: tracing_core
+
+
+### The GStreamer tracers
+
+Several GStreamer tracers are also available so the integration of GStreamer
+tracing and logging into the Rust tracing system is possible without modifying
+the application that uses GStreamer.
+
+For GStreamer to find the tracer you need to ensure that the
+`libtracing_gstreamer.so` is installed as GStreamer plugin (you can also set
+`GST_PLUGIN_PATH` for example with `export
+GST_PLUGIN_PATH=$PWD/target/debug/:$GST_PLUGIN_PATH`).
+
+Currently 2 tracers are available:
+
+* `chrometracing`: This tracer will output the tracing events in the Chrome json
+  tracing format. This will create a `trace-XXX.json` in the current directory
+  that can be opened in [perfetto](https://ui.perfetto.dev/). This is useful to
+  analyze GStreamer performance in a graphical way.
+
+* `fmttracing`: Use the `tracing-subscriber::fmt` subscriber to format the
+  tracing events. This is useful to get a human readable output. To actually get
+  output you also need to set `RUST_LOG=<loglevel>`
+
+> Note that only *one* of those tracer can be used at a time, and the application
+> itself should never activate any other tracing_subscriber.
+
+#### Tracers parameters
+
+The tracer has the following parameters:
+
+* `log-level`: String in the same form as the GST_DEBUG environment variable
+  defining which GStreamer log level and category should be logged into the
+  tracing system. This implies that the usual GStreamer log system will be
+  disabled and the rust one will be used instead.
+
+#### Examples
+
+You can, for example, profile a GStreamer pipeline using [`gst-launch-1.0`]
+with the following command:
+
+##### Using the `chrometracing` tracer
+
+
+``` sh
+# Builds the tracer plugin and make sure GStreamer finds it.
+# Enable the tracer with the chrome tracing output and activating GStreamer info logs
+cargo build && \
+  GST_PLUGIN_PATH=$PWD/target/debug/:$GST_PLUGIN_PATH \
+  GST_TRACERS="chrometracing(log-level=4)" \
+  gst-launch-1.0 playbin3 uri="https://www.freedesktop.org/software/gstreamer-sdk/data/media/sintel_trailer-480p.webm"
+```
+
+A new `trace-XXX.json` file will be created in the current directory. You can
+then open it in [perfetto](https://ui.perfetto.dev/) to analyze them.
+
+
+##### Using the `fmttracing` tracer
+
+
+``` sh
+# Builds the tracer plugin and make sure GStreamer finds it.
+# Enable the tracer with the fmt tracing output and activating GStreamer info logs
+# Logs will be output on stderr in the `tracing-subscriber::fmt` format
+cargo build && \
+  GST_PLUGIN_PATH=$PWD/target/debug/:$GST_PLUGIN_PATH \
+  RUST_LOG=debug GST_TRACERS="fmttracing(log-level=4)" \
+  gst-launch-1.0 playbin3 uri="https://www.freedesktop.org/software/gstreamer-sdk/data/media/sintel_trailer-480p.webm"
+```
+

--- a/src/chrometracer/imp.rs
+++ b/src/chrometracer/imp.rs
@@ -1,0 +1,57 @@
+use gstreamer::{glib, prelude::*, subclass::prelude::*};
+use std::str::FromStr;
+use std::sync::Mutex;
+use tracing::error;
+use tracing_subscriber::prelude::*;
+
+use crate::tracer::{TracingTracer, TracingTracerImpl};
+
+#[derive(Default)]
+struct State {
+    chrome_guard: Option<tracing_chrome::FlushGuard>,
+}
+
+#[derive(Default)]
+pub struct ChromeTracer {
+    state: Mutex<State>,
+}
+
+#[glib::object_subclass]
+impl ObjectSubclass for ChromeTracer {
+    const NAME: &'static str = "ChromeTracer";
+    type Type = super::ChromeTracer;
+    type ParentType = TracingTracer;
+    type Interfaces = ();
+}
+
+impl ObjectImpl for ChromeTracer {
+    fn constructed(&self) {
+        let mut include_args = true;
+
+        if let Some(params) = self.obj().property::<Option<String>>("params") {
+            let tmp = format!("params,{}", params);
+            include_args = gstreamer::Structure::from_str(&tmp)
+                .unwrap_or_else(|e| {
+                    eprintln!("Invalid params string: {:?}: {e:?}", tmp);
+                    gstreamer::Structure::new_empty("params")
+                })
+                .get::<bool>("include-args")
+                .unwrap_or(true)
+        }
+
+        let (chrome_layer, guard) = tracing_chrome::ChromeLayerBuilder::new()
+            .include_args(include_args)
+            .build();
+
+        self.state.lock().unwrap().chrome_guard = Some(guard);
+        if let Err(e) = tracing_subscriber::registry().with(chrome_layer).try_init() {
+            error!("Failed to initialize tracing subscriber: {e:?}");
+        }
+
+        self.parent_constructed();
+    }
+}
+
+impl GstObjectImpl for ChromeTracer {}
+impl TracerImpl for ChromeTracer {}
+impl TracingTracerImpl for ChromeTracer {}

--- a/src/chrometracer/mod.rs
+++ b/src/chrometracer/mod.rs
@@ -1,0 +1,10 @@
+use gstreamer::glib;
+
+use crate::tracer::TracingTracer;
+
+mod imp;
+
+glib::wrapper! {
+    pub struct ChromeTracer(ObjectSubclass<imp::ChromeTracer>)
+       @extends TracingTracer, gstreamer::Tracer, gstreamer::Object;
+}

--- a/src/fmttracer/imp.rs
+++ b/src/fmttracer/imp.rs
@@ -1,0 +1,29 @@
+use tracing::error;
+use gstreamer::{glib, subclass::prelude::*};
+
+use crate::tracer::{TracingTracer, TracingTracerImpl};
+
+#[derive(Default)]
+pub struct FmtTracer {}
+
+#[glib::object_subclass]
+impl ObjectSubclass for FmtTracer {
+    const NAME: &'static str = "FmtTracer";
+    type Type = super::FmtTracer;
+    type ParentType = TracingTracer;
+    type Interfaces = ();
+}
+
+impl ObjectImpl for FmtTracer {
+    fn constructed(&self) {
+        if let Err(e) = tracing_subscriber::fmt::try_init() {
+            error!("Failed to initialize tracing subscriber: {e:?}");
+        }
+
+        self.parent_constructed();
+    }
+}
+
+impl GstObjectImpl for FmtTracer {}
+impl TracerImpl for FmtTracer {}
+impl TracingTracerImpl for FmtTracer {}

--- a/src/fmttracer/mod.rs
+++ b/src/fmttracer/mod.rs
@@ -1,0 +1,10 @@
+use gstreamer::glib;
+
+use crate::tracer::TracingTracer;
+
+mod imp;
+
+glib::wrapper! {
+    pub struct FmtTracer(ObjectSubclass<imp::FmtTracer>)
+       @extends TracingTracer, gstreamer::Tracer, gstreamer::Object;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,10 @@ use tracing_core::field::Value;
 #[macro_use]
 mod macros;
 mod callsite;
+#[cfg(feature = "tracing-chrome")]
+mod chrometracer;
+
+mod fmttracer;
 mod log;
 mod tracer;
 
@@ -139,6 +143,19 @@ pub fn register(p: Option<&gstreamer::Plugin>) -> Result<(), gstreamer::glib::Bo
         p,
         "rusttracing",
         <tracer::TracingTracer as gstreamer::glib::StaticType>::static_type(),
+    )?;
+
+    #[cfg(feature = "tracing-chrome")]
+    gstreamer::Tracer::register(
+        p,
+        "chrometracing",
+        <chrometracer::ChromeTracer as gstreamer::glib::StaticType>::static_type(),
+    )?;
+
+    gstreamer::Tracer::register(
+        p,
+        "fmttracing",
+        <fmttracer::FmtTracer as gstreamer::glib::StaticType>::static_type(),
     )?;
     Ok(())
 }


### PR DESCRIPTION
Allowing to enable subscribers using the tracer parameters. This adds support for the `tracing-chrome` subscriber as it is useful to profile GStreamer applications.