### PR TITLE
Fix: missing features flag in README

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -157,7 +157,7 @@ with the following command:
 ``` sh
 # Builds the tracer plugin and make sure GStreamer finds it.
 # Enable the tracer with the chrome tracing output and activating GStreamer info logs
-cargo build && \
+cargo build --features "tracing-chrome" && \
   GST_PLUGIN_PATH=$PWD/target/debug/:$GST_PLUGIN_PATH \
   GST_TRACERS="chrometracing(log-level=4)" \
   gst-launch-1.0 playbin3 uri="https://www.freedesktop.org/software/gstreamer-sdk/data/media/sintel_trailer-480p.webm"


### PR DESCRIPTION
The `--features "tracing-chrome"` flag was missing from the `README.mkd`. I am not very familiar with rust or tracing and it ended up tripping me up for a bit before I realized I needed to add it to get this tracer to work.