### PR TITLE
Replace `once_cell` dependency with stabilized std `LazyLock`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.mkd"
 description = "Bridge between gstreamer and the tracing ecosystem"
 keywords = ["tracing", "logging", "gstreamer", "multimedia"]
 categories = ["development-tools::debugging", "development-tools::profiling"]
-rust-version = "1.64"
+rust-version = "1.80"
 
 [lib]
 harness = false
@@ -18,7 +18,6 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 libc = "0.2.69"
-once_cell = "1.8.0"
 tracing = "0.1.0"
 tracing-core = "0.1.17"
 gstreamer = "0.23"

--- a/src/callsite.rs
+++ b/src/callsite.rs
@@ -1,4 +1,4 @@
-use once_cell::sync::OnceCell;
+use std::sync::LazyLock;
 use std::{
     alloc::GlobalAlloc,
     sync::{
@@ -165,10 +165,11 @@ impl Ord for Key<'_> {
 
 impl DynamicCallsites {
     pub(crate) fn get() -> &'static Self {
-        static MAP: OnceCell<DynamicCallsites> = OnceCell::new();
-        MAP.get_or_init(|| DynamicCallsites {
+        static MAP: LazyLock<DynamicCallsites> = LazyLock::new(|| DynamicCallsites {
             data: std::sync::Mutex::new(Map::new()),
-        })
+        });
+
+        &MAP
     }
 
     #[allow(clippy::too_many_arguments)] // This is internal to the crate, clippy.


### PR DESCRIPTION
`LazyLock` and friends were stabilized in Rust 1.80, released about a year ago.