### PR TITLE
Make tracing-subscriber dependency optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,15 +23,17 @@ tracing = "0.1.0"
 tracing-core = "0.1.17"
 gstreamer = "0.23"
 thread_local = "1.1"
-tracing-chrome = "0.7.0"
-tracing-subscriber = "0.3"
+tracing-chrome = { version = "0.7.0", optional = true }
+tracing-subscriber = { version = "0.3", optional = true }
 
 [dev-dependencies]
 tracing = "0.1.0"
 tracing-tracy = "0.11"
+tracing-subscriber = "0.3"
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "tracing_gstreamer_docs"]
 
 [features]
-tracing-chrome = []
+tracing-chrome = ["dep:tracing-chrome"]
+tracing-subscriber = ["dep:tracing-subscriber"]

--- a/README.mkd
+++ b/README.mkd
@@ -174,7 +174,7 @@ then open it in [perfetto](https://ui.perfetto.dev/) to analyze them.
 # Builds the tracer plugin and make sure GStreamer finds it.
 # Enable the tracer with the fmt tracing output and activating GStreamer info logs
 # Logs will be output on stderr in the `tracing-subscriber::fmt` format
-cargo build && \
+cargo build --features "tracing-subscriber" && \
   GST_PLUGIN_PATH=$PWD/target/debug/:$GST_PLUGIN_PATH \
   RUST_LOG=debug GST_TRACERS="fmttracing(log-level=4)" \
   gst-launch-1.0 playbin3 uri="https://www.freedesktop.org/software/gstreamer-sdk/data/media/sintel_trailer-480p.webm"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ mod callsite;
 #[cfg(feature = "tracing-chrome")]
 mod chrometracer;
 
+#[cfg(feature = "tracing-subscriber")]
 mod fmttracer;
 mod log;
 mod tracer;
@@ -153,6 +154,7 @@ pub fn register(p: Option<&gstreamer::Plugin>) -> Result<(), gstreamer::glib::Bo
         <chrometracer::ChromeTracer as gstreamer::glib::types::StaticType>::static_type(),
     )?;
 
+    #[cfg(feature = "tracing-subscriber")]
     gstreamer::Tracer::register(
         p,
         "fmttracing",


### PR DESCRIPTION
`tracing-subscriber` is only used by `fmttracing` feature, which itself can only be used when building `tracing-gstreamer` as a gstreamer plugin `.so`. This PR makes the feature optional, so that library users will not have to introduce `tracing-subscriber` into the dependency chain.

It also converts makes `tracing-chrome` dependency explicitly optional.